### PR TITLE
fix: janky error checking when unable to find old preVote

### DIFF
--- a/feeder/priceposter/oracle.go
+++ b/feeder/priceposter/oracle.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"math/big"
-	"strings"
 
 	oracletypes "github.com/NibiruChain/nibiru/x/oracle/types"
 	"github.com/NibiruChain/price-feeder/types"
@@ -69,14 +68,8 @@ func prepareVote(
 		ValidatorAddr: validator.String(),
 	})
 	if err != nil {
-		// TODO(mercilex): a better way?
-		if strings.Contains(err.Error(), oracletypes.ErrNoAggregatePrevote.Error()) {
-			log.Warn().Msg("no aggregate prevote found for this voting period")
-			return nil, nil
-		} else {
-			log.Err(err).Msg("failed to get aggregate prevote from chain")
-			return nil, err
-		}
+		log.Err(err).Msg("failed to get aggregate prevote from chain")
+		return nil, nil
 	}
 
 	// assert equality between feeder's prevote and chain's prevote


### PR DESCRIPTION
When an old prevote is not found on the chain, the error-checking logic is brittle and fails to capture the error. Refer to https://nibiruchain.slack.com/archives/C03DYE815BK/p1675358130691889?thread_ts=1675354625.351299&cid=C03DYE815BK for more details.