### PR TITLE
ci(release): remove unused flags on goreleaser-cross

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,6 @@ release:
 	docker run \
 		--rm \
 		--platform=linux/amd64 \
-		--privileged \
-		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v "$(CURDIR)":/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
 		-e CGO_ENABLED=1 \


### PR DESCRIPTION
Removing `--privileged` and  `docker.sock` mount as we will probably not use goreleaser for building docker.