### PR TITLE
Add coinmarketcap price feeder

### DIFF
--- a/feeder/priceprovider/priceprovider.go
+++ b/feeder/priceprovider/priceprovider.go
@@ -44,6 +44,8 @@ func NewPriceProvider(
 		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.BinancePriceUpdate, logger)
 	case sources.Coingecko:
 		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.CoingeckoPriceUpdate(config), logger)
+	case sources.Coinmarketcap:
+		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.CoinmarketcapPriceUpdate(config), logger)
 	default:
 		panic("unknown price provider: " + sourceName)
 	}

--- a/feeder/priceprovider/sources/coinmarketcap.go
+++ b/feeder/priceprovider/sources/coinmarketcap.go
@@ -1,0 +1,141 @@
+package sources
+
+import (
+	json2 "encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/NibiruChain/nibiru/x/common/set"
+	"github.com/NibiruChain/pricefeeder/types"
+	"github.com/tendermint/tendermint/libs/json"
+)
+
+const (
+	CoiCoinmarketcap   = "coinmarketcap"
+	Link    = "https://pro-api.coinmarketcap.com/v2/cryptocurrency/quotes/latest"
+	ApiKeyParam = "X-CMC_PRO_API_KEY"
+)
+
+type Cmcquoteprice struct {
+	Price float64
+}
+
+type Cmcquote struct {
+	USD Cmcquoteprice
+}
+
+type CmcTicker struct {
+	Slug string
+	Quote Cmcquote
+}
+
+type CmcResponse struct {
+	Data map[string]CmcTicker
+}
+
+type CoinmarketcapConfig struct {
+	ApiKey string `json:"api_key"`
+}
+
+type CmcTicker struct {
+	Price float64 
+}
+
+func CoinmarketcapPriceUpdate(jsonConfig json2.RawMessage) types.FetchPricesFunc {
+	return func(symbols set.Set[types.Symbol]) (map[types.Symbol]float64, error) {
+		client := &http.Client{}
+
+		c, err := extractConfig(jsonConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		req, err := buildReq(symbols, c)
+		if err != nil {
+			return nil, err
+		}
+
+		res, err := client.Do(req);
+		if err != nil {
+			return nil, err
+		}
+		defer res.Body.Close()
+
+		response, err := io.ReadAll(res.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		rawPrices, err := extractPricesFromResponse(symbols, response)
+		if err != nil {
+			return nil, err
+		}
+
+		return rawPrices, nil
+	}
+}
+
+// extractConfig tries to get the configuration, if nothing is found, it returns an empty config.
+func extractConfig(jsonConfig json2.RawMessage) (*CoinmarketcapConfig, error) {
+	c := &CoinmarketcapConfig{}
+	if len(jsonConfig) > 0 {
+		err := json.Unmarshal(jsonConfig, c)
+		if err != nil {
+			return nil, fmt.Errorf("invalid coinmarketcap config: %w", err)
+		}
+	}
+	return c, nil
+}
+
+func extractPricesFromResponse(symbols set.Set[types.Symbol], response []byte) (map[types.Symbol]float64, error) {
+	var respCmc CmcResponse
+	err := json.Unmarshal(response, &respCmc)
+	if err != nil {
+		return nil, err
+	}
+
+	cmcPrice := make(map[string]float64)
+	for _,value  := range result.Data {
+			cmcPrice[value.Slug] = value.Quote.USD.Price
+	}
+
+	rawPrices := make(map[types.Symbol]float64)
+	for symbol := range symbols {
+		if price, ok := cmcPrice[string(symbol)]; ok {
+			rawPrices[symbol] = price
+		} else {
+			return nil, fmt.Errorf("symbol %s not found in response: %s\n", symbol, response)
+		}
+	}
+
+	return rawPrices, err
+}
+
+func buildReq(symbols set.Set[types.Symbol], c *CoinmarketcapConfig) string {
+
+	req, err := http.NewRequest("GET", Link, nil)
+	if err != nil {
+		return nil, fmt.Errorf("Can not create a requet with link: %s\n", Link)
+	}
+
+	params := url.Values{}
+	params.Add("symbol", coinmarketcapSymbolCsv(symbols))
+
+	req.Header.Set("Accepts", "application/json")
+	req.Header.Add(ApiKeyParam, c.ApiKey)
+	req.URL.RawQuery = q.Encode()
+
+	return req
+}
+
+// coinmarketcapSymbolCsv returns the symbols as a comma separated string.
+func coinmarketcapSymbolCsv(symbols set.Set[types.Symbol]) string {
+	s := ""
+	for symbol := range symbols {
+		s += string(symbol) + ","
+	}
+
+	return s[:len(s)-1]
+}

--- a/feeder/priceprovider/sources/coinmarketcap_test.go
+++ b/feeder/priceprovider/sources/coinmarketcap_test.go
@@ -1,0 +1,34 @@
+package sources
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/NibiruChain/nibiru/x/common/set"
+	"github.com/NibiruChain/pricefeeder/types"
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoinmarketcapPriceUpdate(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	t.Run("success", func(t *testing.T) {
+		httpmock.RegisterResponder(
+			"GET", Link+"?slug=bitcoin%2Cethereum",
+			httpmock.NewStringResponder(200, "{\"status\": {\"error_code\":0},\"data\":{\"1\":{\"slug\":\"bitcoin\",\"quote\":{\"USD\":{\"price\":23829}}}, \"100\":{\"slug\":\"ethereum\",\"quote\":{\"USD\":{\"price\":1676.85}}}}}"),
+		)
+		rawPrices, err := CoinmarketcapPriceUpdate(json.RawMessage{})(
+			set.New[types.Symbol](
+				"bitcoin",
+				"ethereum",
+			),
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, 2, len(rawPrices))
+		require.Equal(t, rawPrices["bitcoin"], 23829.0)
+		require.Equal(t, rawPrices["ethereum"], 1676.85)
+	})
+}


### PR DESCRIPTION
The datasource requires configuration:

DATASOURCE_CONFIG_MAP='{"coinmarketcap": {"api_key": "0123456789"}}'

As symbols  in 
EXCHANGE_SYMBOLS_MAP='{"coinmarketcap": {"ubtc:unusd": "bitcoin"}}'
it should be referenced "slug" values of the coinmarketcap quotes API because slug values are unique for the tokens:
https://coinmarketcap.com/api/documentation/v1/#operation/getV2CryptocurrencyQuotesLatest



Limitation of the solution:
- supports prices in USD (could be refactored later)
- since my validator "swissstar" not in active set, it commit was not tested against active validator but again test method