### PR TITLE
Add OKEX data source

### DIFF
--- a/feeder/priceprovider/priceprovider.go
+++ b/feeder/priceprovider/priceprovider.go
@@ -44,6 +44,8 @@ func NewPriceProvider(
 		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.BinancePriceUpdate, logger)
 	case sources.Coingecko:
 		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.CoingeckoPriceUpdate(config), logger)
+	case sources.Okex:
+		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.OkexPriceUpdate, logger)
 	default:
 		panic("unknown price provider: " + sourceName)
 	}

--- a/feeder/priceprovider/sources/okex.go
+++ b/feeder/priceprovider/sources/okex.go
@@ -1,0 +1,67 @@
+package sources
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/NibiruChain/nibiru/x/common/set"
+	"github.com/NibiruChain/pricefeeder/types"
+)
+
+const (
+	Okex = "okex"
+)
+
+var _ types.FetchPricesFunc = OkexPriceUpdate
+
+type OkexTicker struct {
+	Symbol string `json:"instId"`
+	Price  string `json:"last"`
+}
+
+type Response struct {
+	Data []OkexTicker `json:"data"`
+}
+
+// OkexPriceUpdate returns the prices for given symbols or an error.
+// Uses OKEX API at https://www.okx.com/docs-v5/en/#rest-api-market-data.
+func OkexPriceUpdate(symbols set.Set[types.Symbol]) (rawPrices map[types.Symbol]float64, err error) {
+
+	url := "https://www.okx.com/api/v5/market/tickers?instType=SPOT"
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var response Response
+	err = json.Unmarshal(b, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	rawPrices = make(map[types.Symbol]float64)
+	for _, ticker := range response.Data {
+
+		symbol := types.Symbol(strings.Replace(ticker.Symbol, "-", "", -1))
+		price, err := strconv.ParseFloat(ticker.Price, 64)
+		if err != nil {
+			return rawPrices, err
+		}
+
+		if _, ok := symbols[symbol]; ok {
+			rawPrices[symbol] = price
+		}
+
+	}
+	return rawPrices, nil
+}

--- a/feeder/priceprovider/sources/okex_test.go
+++ b/feeder/priceprovider/sources/okex_test.go
@@ -1,0 +1,20 @@
+package sources
+
+import (
+	"testing"
+
+	"github.com/NibiruChain/nibiru/x/common/set"
+	"github.com/NibiruChain/pricefeeder/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOKexPriceUpdate(t *testing.T) {
+
+	t.Run("success", func(t *testing.T) {
+		rawPrices, err := OkexPriceUpdate(set.New[types.Symbol]("BTCUSDT", "ETHUSDT"))
+		require.NoError(t, err)
+		require.Equal(t, 2, len(rawPrices))
+		require.NotZero(t, rawPrices["BTCUSDT"])
+		require.NotZero(t, rawPrices["ETHUSDT"])
+	})
+}


### PR DESCRIPTION
Phase 1 Developer task (Contribute a data source to the [pricefeeder repo](https://github.com/NibiruChain/pricefeeder)) on Behalf of NODEJUMPER validator team:
https://nibiru.explorers.guru/validator/nibivaloper1r9kmadqs9nsppn4wz5yp4rw8zn9545rcueqhyr

Pulls data from:
https://www.okx.com/docs-v5/en/#rest-api-market-data