### PR TITLE
feat(observability): add prometheus metrics

### DIFF
--- a/cmd/feeder/main.go
+++ b/cmd/feeder/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"flag"
+	"net/http"
 	"os"
 	"os/signal"
 
 	"github.com/NibiruChain/nibiru/app"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog"
 
 	"github.com/NibiruChain/pricefeeder/config"
@@ -49,7 +51,8 @@ func main() {
 
 	handleInterrupt(logger, f)
 
-	select {}
+	http.Handle("/metrics", promhttp.Handler())
+	http.ListenAndServe(":3000", nil)
 }
 
 // handleInterrupt listens for SIGINT and gracefully shuts down the feeder.

--- a/cmd/feeder/main.go
+++ b/cmd/feeder/main.go
@@ -52,7 +52,13 @@ func main() {
 	handleInterrupt(logger, f)
 
 	http.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe(":3000", nil)
+	go func() {
+		if err := http.ListenAndServe(":3000", nil); err != nil {
+			logger.Error().Err(err).Msg("Metrics HTTP server failed")
+		}
+	}()
+
+	select {}
 }
 
 // handleInterrupt listens for SIGINT and gracefully shuts down the feeder.

--- a/feeder/priceposter/client.go
+++ b/feeder/priceposter/client.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/NibiruChain/nibiru/app"
 	oracletypes "github.com/NibiruChain/nibiru/x/oracle/types"
+	"github.com/NibiruChain/pricefeeder/metrics"
 	"github.com/NibiruChain/pricefeeder/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -117,6 +118,8 @@ func (c *Client) SendPrices(vp types.VotingPeriod, prices []types.Price) {
 
 	c.previousPrevote = newPrevote
 	logger.Info().Str("tx-hash", resp.TxHash).Msg("successfully forwarded prices")
+
+	metrics.NumVotingPeriods.Inc()
 }
 
 func (c *Client) Close() {

--- a/feeder/priceprovider/priceprovider.go
+++ b/feeder/priceprovider/priceprovider.go
@@ -39,13 +39,13 @@ func NewPriceProvider(
 	var source types.Source
 	switch sourceName {
 	case sources.Bitfinex:
-		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.BitfinexPriceUpdate, logger)
+		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.BitfinexPriceUpdate, logger, sources.Bitfinex)
 	case sources.Binance:
-		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.BinancePriceUpdate, logger)
+		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.BinancePriceUpdate, logger, sources.Binance)
 	case sources.Coingecko:
-		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.CoingeckoPriceUpdate(config), logger)
+		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.CoingeckoPriceUpdate(config), logger, sources.Coingecko)
 	case sources.CoinMarketCap:
-		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.CoinmarketcapPriceUpdate(config), logger)
+		source = sources.NewTickSource(symbolsFromPairToSymbolMapping(pairToSymbolMap), sources.CoinmarketcapPriceUpdate(config), logger, sources.CoinMarketCap)
 	default:
 		panic("unknown price provider: " + sourceName)
 	}

--- a/feeder/priceprovider/sources/tick_source_test.go
+++ b/feeder/priceprovider/sources/tick_source_test.go
@@ -29,7 +29,7 @@ func TestTickSource(t *testing.T) {
 		ts := NewTickSource(expectedSymbols, func(symbols set.Set[types.Symbol]) (map[types.Symbol]float64, error) {
 			require.Equal(t, expectedSymbols, symbols)
 			return expectedPrices, nil
-		}, zerolog.New(io.Discard))
+		}, zerolog.New(io.Discard), "test_source")
 
 		defer ts.Close()
 
@@ -63,7 +63,7 @@ func TestTickSource(t *testing.T) {
 
 		ts := NewTickSource(expectedSymbols, func(symbols set.Set[types.Symbol]) (map[types.Symbol]float64, error) {
 			return expectedPrices, nil
-		}, zerolog.New(mw))
+		}, zerolog.New(mw), "test_source")
 
 		<-time.After(UpdateTick + 1*time.Second) // wait for a tick update
 		ts.Close()                               // make the update be dropped because of close
@@ -82,7 +82,7 @@ func TestTickSource(t *testing.T) {
 
 		ts := NewTickSource(set.New[types.Symbol]("tBTCUSDT"), func(symbols set.Set[types.Symbol]) (map[types.Symbol]float64, error) {
 			return nil, fmt.Errorf("sentinel error")
-		}, zerolog.New(mw))
+		}, zerolog.New(mw), "test_source")
 		defer ts.Close()
 
 		<-time.After(UpdateTick + 1*time.Second) // wait for a tick update

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,28 @@
+# Metrics in metrics.go
+
+This file defines two metrics that are used to monitor the performance and behavior of the pricefeeder application.
+
+## pricefeeder_voting_periods_total
+
+This is a counter metric that keeps track of the total number of voting periods the pricefeeder has participated in. A voting period is a specific duration during which votes are collected. This metric is incremented each time the pricefeeder participates in a voting period.
+
+```go
+var NumVotingPeriods = promauto.NewCounter(prometheus.CounterOpts{
+    Name: "pricefeeder_voting_periods_total",
+    Help: "The total number of voting periods this pricefeeder has participated in",
+})
+```
+
+## pricefeeder_price_source_latency_seconds
+
+This is a histogram metric that measures the latency of querying a price source in seconds. The latency is the amount of time it takes for the pricefeeder to receive a response after it has sent a request to the price source. This metric is useful for monitoring the performance of the price sources and identifying any potential issues or delays.
+
+```go
+var PriceSourceLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+    Name:    "pricefeeder_price_source_latency_seconds",
+    Help:    "The latency of querying a price source in seconds",
+    Buckets: prometheus.DefBuckets,
+}, []string{"source"})
+```
+
+The source label is used to differentiate the latencies of different price sources.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -9,3 +9,9 @@ var NumVotingPeriods = promauto.NewCounter(prometheus.CounterOpts{
 	Name: "pricefeeder_voting_periods_total",
 	Help: "The total number of voting periods this pricefeeder has participated in",
 })
+
+var PriceSourceLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	Name:    "pricefeeder_price_source_latency_seconds",
+	Help:    "The latency of querying a price source in seconds",
+	Buckets: prometheus.DefBuckets,
+}, []string{"source"})

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,11 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var NumVotingPeriods = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "pricefeeder_voting_periods_total",
+	Help: "The total number of voting periods this pricefeeder has participated in",
+})


### PR DESCRIPTION
This PR defines two metrics that are used to monitor the performance and behavior of the pricefeeder application.

## pricefeeder_voting_periods_total

This is a counter metric that keeps track of the total number of voting periods the pricefeeder has participated in. A voting period is a specific duration during which votes are collected. This metric is incremented each time the pricefeeder participates in a voting period.

```go
var NumVotingPeriods = promauto.NewCounter(prometheus.CounterOpts{
    Name: "pricefeeder_voting_periods_total",
    Help: "The total number of voting periods this pricefeeder has participated in",
})
```

## pricefeeder_price_source_latency_seconds

This is a histogram metric that measures the latency of querying a price source in seconds. The latency is the amount of time it takes for the pricefeeder to receive a response after it has sent a request to the price source. This metric is useful for monitoring the performance of the price sources and identifying any potential issues or delays.

```go
var PriceSourceLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
    Name:    "pricefeeder_price_source_latency_seconds",
    Help:    "The latency of querying a price source in seconds",
    Buckets: prometheus.DefBuckets,
}, []string{"source"})
```

The source label is used to differentiate the latencies of different price sources.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced Prometheus metrics for monitoring the application's performance.
  - Added an HTTP server to expose a `/metrics` endpoint for Prometheus scraping.

- **Enhancements**
  - Improved the `SendPrices` function to increment a counter for tracking voting periods.
  - Enhanced price source handling by passing source type information to the `NewTickSource` function.

- **Documentation**
  - Updated the README to include information about new monitoring metrics.

- **Tests**
  - Modified test cases to accommodate the new parameter in the `NewTickSource` function calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->