### PR TITLE
avoid parsing if EXCHANGE_SYMBOLS_MAP is not define.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -91,7 +91,7 @@ func Get() (*Config, error) {
 		overrideExchangeSymbolsMap := map[string]map[string]string{}
 		err := json.Unmarshal([]byte(overrideExchangeSymbolsMapJson), &overrideExchangeSymbolsMap)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse EXCHANGE_SYMBOLS_MAP: invalid json")
+			return nil, fmt.Errorf("failed to parse EXCHANGE_SYMBOLS_MAP: %w", err)
 		}
 		for exchange, symbolMap := range overrideExchangeSymbolsMap {
 			conf.ExchangesToPairToSymbolMap[exchange] = map[asset.Pair]types.Symbol{}

--- a/config/config.go
+++ b/config/config.go
@@ -84,18 +84,20 @@ func Get() (*Config, error) {
 	conf.WebsocketEndpoint = os.Getenv("WEBSOCKET_ENDPOINT")
 	conf.FeederMnemonic = os.Getenv("FEEDER_MNEMONIC")
 	conf.EnableTLS = os.Getenv("ENABLE_TLS") == "true"
-	overrideExchangeSymbolsMapJson := os.Getenv("EXCHANGE_SYMBOLS_MAP")
-	overrideExchangeSymbolsMap := map[string]map[string]string{}
-	err := json.Unmarshal([]byte(overrideExchangeSymbolsMapJson), &overrideExchangeSymbolsMap)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse EXCHANGE_SYMBOLS_MAP: invalid json")
-	}
-
 	conf.ExchangesToPairToSymbolMap = defaultExchangeSymbolsMap
-	for exchange, symbolMap := range overrideExchangeSymbolsMap {
-		conf.ExchangesToPairToSymbolMap[exchange] = map[asset.Pair]types.Symbol{}
-		for nibiAssetPair, tickerSymbol := range symbolMap {
-			conf.ExchangesToPairToSymbolMap[exchange][asset.MustNewPair(nibiAssetPair)] = types.Symbol(tickerSymbol)
+
+	overrideExchangeSymbolsMapJson := os.Getenv("EXCHANGE_SYMBOLS_MAP")
+	if overrideExchangeSymbolsMapJson != "" {
+		overrideExchangeSymbolsMap := map[string]map[string]string{}
+		err := json.Unmarshal([]byte(overrideExchangeSymbolsMapJson), &overrideExchangeSymbolsMap)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse EXCHANGE_SYMBOLS_MAP: invalid json")
+		}
+		for exchange, symbolMap := range overrideExchangeSymbolsMap {
+			conf.ExchangesToPairToSymbolMap[exchange] = map[asset.Pair]types.Symbol{}
+			for nibiAssetPair, tickerSymbol := range symbolMap {
+				conf.ExchangesToPairToSymbolMap[exchange][asset.MustNewPair(nibiAssetPair)] = types.Symbol(tickerSymbol)
+			}
 		}
 	}
 
@@ -104,7 +106,7 @@ func Get() (*Config, error) {
 	datasourceConfigMap := map[string]json.RawMessage{}
 
 	if datasourceConfigMapJson != "" {
-		err = json.Unmarshal([]byte(datasourceConfigMapJson), &datasourceConfigMap)
+		err := json.Unmarshal([]byte(datasourceConfigMapJson), &datasourceConfigMap)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse DATASOURCE_CONFIG_MAP: invalid json")
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -21,5 +22,18 @@ func TestConfig_Get(t *testing.T) {
 	app.SetPrefixes(app.AccountAddressPrefix)
 	os.Setenv("VALIDATOR_ADDRESS", "nibivaloper1d7zygazerfwx4l362tnpcp0ramzm97xvv9ryxr")
 	_, err := Get()
+	require.NoError(t, err)
+}
+
+func TestConfig_Without_EXCHANGE_SYMBOLS_MAP(t *testing.T) {
+
+	os.Setenv("CHAIN_ID", "nibiru-localnet-0")
+	os.Setenv("GRPC_ENDPOINT", "localhost:9090")
+	os.Setenv("WEBSOCKET_ENDPOINT", "ws://localhost:26657/websocket")
+	os.Setenv("FEEDER_MNEMONIC", "earth wash broom grow recall fitness")
+	app.SetPrefixes(app.AccountAddressPrefix)
+	os.Setenv("VALIDATOR_ADDRESS", "nibivaloper1d7zygazerfwx4l362tnpcp0ramzm97xvv9ryxr")
+	cfg, err := Get()
+	fmt.Println(cfg)
 	require.NoError(t, err)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,7 +26,7 @@ func TestConfig_Get(t *testing.T) {
 }
 
 func TestConfig_Without_EXCHANGE_SYMBOLS_MAP(t *testing.T) {
-
+   os.Unsetenv("EXCHANGE_SYMBOLS_MAP")
 	os.Setenv("CHAIN_ID", "nibiru-localnet-0")
 	os.Setenv("GRPC_ENDPOINT", "localhost:9090")
 	os.Setenv("WEBSOCKET_ENDPOINT", "ws://localhost:26657/websocket")


### PR DESCRIPTION
Will use defaultExchangeSymbolsMap instead of fail if EXCHANGE_SYMBOLS_MAP  is not define

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Improved handling and parsing of configuration data for enhanced stability.
- **Tests**
	- Added tests to ensure reliable configuration loading without specific environment variables.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->