### PR TITLE
feat(observability): add prometheus metrics and detailed logging

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ env:
 
 builds:
   - id: darwin
-    main: ./cmd/feeder
+    main: .
     binary: pricefeeder
     hooks:
       pre:
@@ -35,7 +35,7 @@ builds:
           - CC=oa64-clang
 
   - id: linux
-    main: ./cmd/feeder
+    main: .
     binary: pricefeeder
     hooks:
       pre:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go mod download
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
   --mount=type=cache,target=/go/pkg \
-  go build -o ./build/feeder ./cmd/feeder/
+  go build -o ./build/feeder .
 
 FROM gcr.io/distroless/static:nonroot
 

--- a/Makefile
+++ b/Makefile
@@ -44,16 +44,15 @@ release:
 		-e CGO_ENABLED=1 \
 		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
 		goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		release --clean
+		release --rm-dist
 
 release-snapshot:
 	docker run \
 		--rm \
 		--platform=linux/amd64 \
-		-v /tmp:/tmp \
 		-v "$(CURDIR)":/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
 		-e CGO_ENABLED=1 \
 		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
 		goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		release --clean --snapshot
+		release --rm-dist --snapshot

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,16 @@ release:
 		-e CGO_ENABLED=1 \
 		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
 		goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		release --rm-dist
+		release --clean
+
+release-snapshot:
+	docker run \
+		--rm \
+		--platform=linux/amd64 \
+		-v /tmp:/tmp \
+		-v "$(CURDIR)":/go/src/$(PACKAGE_NAME) \
+		-w /go/src/$(PACKAGE_NAME) \
+		-e CGO_ENABLED=1 \
+		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
+		goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		release --clean --snapshot

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ test:
 	go test ./...
 
 run:
-	go run ./cmd/feeder/main.go
+	go run ./main.go
 
 run-debug:
-	go run ./cmd/feeder/main.go -debug true
+	go run ./main.go -debug true
 
 ###############################################################################
 ###                                Build                                    ###

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This would allow you to run `pricefeeder` using a local instance of the network.
 ```bash
 git clone git@github.com:NibiruChain/nibiru.git
 cd nibiru
-git checkout v1.0.0
+git checkout v1.0.3
 make localnet
 ```
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/NibiruChain/pricefeeder/feeder/eventstream"
 	"github.com/NibiruChain/pricefeeder/feeder/priceposter"
 	"github.com/NibiruChain/pricefeeder/feeder/priceprovider"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 )
@@ -65,6 +67,9 @@ var rootCmd = &cobra.Command{
 		defer f.Close()
 
 		handleInterrupt(logger, f)
+
+		http.Handle("/metrics", promhttp.Handler())
+		http.ListenAndServe(":8080", nil)
 
 		select {}
 	},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of Hugo",
+	Long:  `All software has versions. This is Hugo's`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Hugo Static Site Generator v0.9 -- HEAD")
+	},
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,6 +15,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of Hugo",
 	Long:  `All software has versions. This is Hugo's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Hugo Static Site Generator v0.9 -- HEAD")
+		fmt.Println("v1.0.3")
 	},
 }

--- a/feeder/priceprovider/aggregateprovider.go
+++ b/feeder/priceprovider/aggregateprovider.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/NibiruChain/nibiru/x/common/asset"
 	"github.com/NibiruChain/pricefeeder/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog"
 )
 
@@ -37,6 +39,11 @@ func NewAggregatePriceProvider(
 	}
 }
 
+var aggregatePriceProvider = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "aggregate_price_provider_prices_total",
+	Help: "The total number prices provided by the aggregate price provider, by pair, source, and success status",
+}, []string{"pair", "source", "success"})
+
 // GetPrice fetches the first available and correct price from the wrapped PriceProviders.
 // Iteration is exhaustive and random.
 // If no correct PriceResponse is found, then an invalid PriceResponse is returned.
@@ -46,12 +53,14 @@ func (a AggregatePriceProvider) GetPrice(pair asset.Pair) types.Price {
 	for _, p := range a.providers {
 		price := p.GetPrice(pair)
 		if price.Valid {
+			aggregatePriceProvider.WithLabelValues(pair.String(), price.SourceName, "true").Inc()
 			return price
 		}
 	}
 
 	// if we reach here no valid symbols were found
 	a.logger.Warn().Str("pair", pair.String()).Msg("no valid price found")
+	aggregatePriceProvider.WithLabelValues(pair.String(), "missing", "false").Inc()
 	return types.Price{
 		SourceName: "missing",
 		Pair:       pair,

--- a/feeder/priceprovider/aggregateprovider.go
+++ b/feeder/priceprovider/aggregateprovider.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/NibiruChain/nibiru/x/common/asset"
+	"github.com/NibiruChain/pricefeeder/metrics"
 	"github.com/NibiruChain/pricefeeder/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -40,8 +41,9 @@ func NewAggregatePriceProvider(
 }
 
 var aggregatePriceProvider = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "aggregate_price_provider_prices_total",
-	Help: "The total number prices provided by the aggregate price provider, by pair, source, and success status",
+	Namespace: metrics.PrometheusNamespace,
+	Name:      "aggregate_prices_total",
+	Help:      "The total number prices provided by the aggregate price provider, by pair, source, and success status",
 }, []string{"pair", "source", "success"})
 
 // GetPrice fetches the first available and correct price from the wrapped PriceProviders.

--- a/feeder/priceprovider/sources/binance.go
+++ b/feeder/priceprovider/sources/binance.go
@@ -36,12 +36,14 @@ func BinancePriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (r
 	url := "https://api.binance.us/api/v3/ticker/price?symbols=%5B" + BinanceSymbolCsv(symbols) + "%5D"
 	resp, err := http.Get(url)
 	if err != nil {
+		logger.Err(err).Msg("failed to fetch prices from Binance")
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
+		logger.Err(err).Msg("failed to read response body from Binance")
 		return nil, err
 	}
 
@@ -49,6 +51,7 @@ func BinancePriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (r
 
 	err = json.Unmarshal(b, &tickers)
 	if err != nil {
+		logger.Err(err).Msg("failed to unmarshal response body from Binance")
 		return nil, err
 	}
 

--- a/feeder/priceprovider/sources/bitfinex.go
+++ b/feeder/priceprovider/sources/bitfinex.go
@@ -35,18 +35,21 @@ func BitfinexPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (
 	var url string = "https://api-pub.bitfinex.com/v2/tickers?symbols=" + BitfinexSymbolCsv(symbols)
 	resp, err := http.Get(url)
 	if err != nil {
+		logger.Err(err).Msg("failed to fetch prices from Bitfinex")
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
+		logger.Err(err).Msg("failed to read response body from Bitfinex")
 		return nil, err
 	}
 	var tickers []ticker
 
 	err = json.Unmarshal(b, &tickers)
 	if err != nil {
+		logger.Err(err).Msg("failed to unmarshal response body from Bitfinex")
 		return nil, err
 	}
 

--- a/feeder/priceprovider/sources/bybit.go
+++ b/feeder/priceprovider/sources/bybit.go
@@ -33,18 +33,21 @@ func BybitPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (raw
 
 	resp, err := http.Get(url)
 	if err != nil {
+		logger.Err(err).Msg("failed to fetch prices from Bybit")
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
+		logger.Err(err).Msg("failed to read response body from Bybit")
 		return nil, err
 	}
 
 	var response BybitResponse
 	err = json.Unmarshal(b, &response)
 	if err != nil {
+		logger.Err(err).Msg("failed to unmarshal response body from Bybit")
 		return nil, err
 	}
 

--- a/feeder/priceprovider/sources/bybit.go
+++ b/feeder/priceprovider/sources/bybit.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/NibiruChain/nibiru/x/common/set"
+	"github.com/NibiruChain/pricefeeder/metrics"
 	"github.com/NibiruChain/pricefeeder/types"
 	"github.com/rs/zerolog"
 )
@@ -34,6 +35,7 @@ func BybitPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (raw
 	resp, err := http.Get(url)
 	if err != nil {
 		logger.Err(err).Msg("failed to fetch prices from Bybit")
+		metrics.PriceSourceCounter.WithLabelValues(Bybit, "false").Inc()
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -41,6 +43,7 @@ func BybitPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (raw
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Err(err).Msg("failed to read response body from Bybit")
+		metrics.PriceSourceCounter.WithLabelValues(Bybit, "false").Inc()
 		return nil, err
 	}
 
@@ -48,6 +51,7 @@ func BybitPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (raw
 	err = json.Unmarshal(b, &response)
 	if err != nil {
 		logger.Err(err).Msg("failed to unmarshal response body from Bybit")
+		metrics.PriceSourceCounter.WithLabelValues(Bybit, "false").Inc()
 		return nil, err
 	}
 
@@ -66,5 +70,6 @@ func BybitPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (raw
 		}
 	}
 	logger.Debug().Msgf("fetched prices for %s on data source %s: %v", symbols, Bybit, rawPrices)
+	metrics.PriceSourceCounter.WithLabelValues(Bybit, "true").Inc()
 	return rawPrices, nil
 }

--- a/feeder/priceprovider/sources/coingecko.go
+++ b/feeder/priceprovider/sources/coingecko.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/NibiruChain/nibiru/x/common/set"
+	"github.com/NibiruChain/pricefeeder/metrics"
 	"github.com/NibiruChain/pricefeeder/types"
 	"github.com/rs/zerolog"
 )
@@ -32,12 +33,14 @@ func CoingeckoPriceUpdate(sourceConfig json.RawMessage) types.FetchPricesFunc {
 		c, err := extractConfig(sourceConfig)
 		if err != nil {
 			logger.Err(err).Msg("failed to extract coingecko config")
+			metrics.PriceSourceCounter.WithLabelValues(Coingecko, "false").Inc()
 			return nil, err
 		}
 
 		res, err := http.Get(buildURL(symbols, c))
 		if err != nil {
 			logger.Err(err).Msg("failed to fetch prices from Coingecko")
+			metrics.PriceSourceCounter.WithLabelValues(Coingecko, "false").Inc()
 			return nil, err
 		}
 		defer res.Body.Close()
@@ -45,15 +48,18 @@ func CoingeckoPriceUpdate(sourceConfig json.RawMessage) types.FetchPricesFunc {
 		response, err := io.ReadAll(res.Body)
 		if err != nil {
 			logger.Err(err).Msg("failed to read response body from Coingecko")
+			metrics.PriceSourceCounter.WithLabelValues(Coingecko, "false").Inc()
 			return nil, err
 		}
 
 		rawPrices, err := extractPricesFromResponse(symbols, response, logger)
 		if err != nil {
 			logger.Err(err).Msg("failed to extract prices from Coingecko response")
+			metrics.PriceSourceCounter.WithLabelValues(Coingecko, "false").Inc()
 			return nil, err
 		}
 
+		metrics.PriceSourceCounter.WithLabelValues(Coingecko, "true").Inc()
 		return rawPrices, nil
 	}
 }

--- a/feeder/priceprovider/sources/coingecko.go
+++ b/feeder/priceprovider/sources/coingecko.go
@@ -31,22 +31,26 @@ func CoingeckoPriceUpdate(sourceConfig json.RawMessage) types.FetchPricesFunc {
 	return func(symbols set.Set[types.Symbol], logger zerolog.Logger) (map[types.Symbol]float64, error) {
 		c, err := extractConfig(sourceConfig)
 		if err != nil {
+			logger.Err(err).Msg("failed to extract coingecko config")
 			return nil, err
 		}
 
 		res, err := http.Get(buildURL(symbols, c))
 		if err != nil {
+			logger.Err(err).Msg("failed to fetch prices from Coingecko")
 			return nil, err
 		}
 		defer res.Body.Close()
 
 		response, err := io.ReadAll(res.Body)
 		if err != nil {
+			logger.Err(err).Msg("failed to read response body from Coingecko")
 			return nil, err
 		}
 
 		rawPrices, err := extractPricesFromResponse(symbols, response, logger)
 		if err != nil {
+			logger.Err(err).Msg("failed to extract prices from Coingecko response")
 			return nil, err
 		}
 

--- a/feeder/priceprovider/sources/coinmarketcap.go
+++ b/feeder/priceprovider/sources/coinmarketcap.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/NibiruChain/nibiru/x/common/set"
+	"github.com/NibiruChain/pricefeeder/metrics"
 	"github.com/NibiruChain/pricefeeder/types"
 	"github.com/rs/zerolog"
 )
@@ -45,12 +46,14 @@ func CoinmarketcapPriceUpdate(coinmarketcapConfig json.RawMessage) types.FetchPr
 		config, err := getConfig(coinmarketcapConfig)
 		if err != nil {
 			logger.Err(err).Msg("failed to extract coinmarketcap config")
+			metrics.PriceSourceCounter.WithLabelValues(CoinMarketCap, "false").Inc()
 			return nil, err
 		}
 
 		req, err := buildReq(symbols, config)
 		if err != nil {
 			logger.Err(err).Msg("failed to build request for Coinmarketcap")
+			metrics.PriceSourceCounter.WithLabelValues(CoinMarketCap, "false").Inc()
 			return nil, err
 		}
 
@@ -58,6 +61,7 @@ func CoinmarketcapPriceUpdate(coinmarketcapConfig json.RawMessage) types.FetchPr
 		res, err := client.Do(req)
 		if err != nil {
 			logger.Err(err).Msg("failed to fetch prices from Coinmarketcap")
+			metrics.PriceSourceCounter.WithLabelValues(CoinMarketCap, "false").Inc()
 			return nil, err
 		}
 		defer res.Body.Close()
@@ -65,15 +69,18 @@ func CoinmarketcapPriceUpdate(coinmarketcapConfig json.RawMessage) types.FetchPr
 		response, err := io.ReadAll(res.Body)
 		if err != nil {
 			logger.Err(err).Msg("failed to read response body from Coinmarketcap")
+			metrics.PriceSourceCounter.WithLabelValues(CoinMarketCap, "false").Inc()
 			return nil, err
 		}
 
 		rawPrices, err := getPricesFromResponse(symbols, response, logger)
 		if err != nil {
 			logger.Err(err).Msg("failed to extract prices from Coinmarketcap response")
+			metrics.PriceSourceCounter.WithLabelValues(CoinMarketCap, "false").Inc()
 			return nil, err
 		}
 
+		metrics.PriceSourceCounter.WithLabelValues(CoinMarketCap, "true").Inc()
 		return rawPrices, nil
 	}
 }

--- a/feeder/priceprovider/sources/coinmarketcap.go
+++ b/feeder/priceprovider/sources/coinmarketcap.go
@@ -44,28 +44,33 @@ func CoinmarketcapPriceUpdate(coinmarketcapConfig json.RawMessage) types.FetchPr
 	return func(symbols set.Set[types.Symbol], logger zerolog.Logger) (map[types.Symbol]float64, error) {
 		config, err := getConfig(coinmarketcapConfig)
 		if err != nil {
+			logger.Err(err).Msg("failed to extract coinmarketcap config")
 			return nil, err
 		}
 
 		req, err := buildReq(symbols, config)
 		if err != nil {
+			logger.Err(err).Msg("failed to build request for Coinmarketcap")
 			return nil, err
 		}
 
 		client := &http.Client{}
 		res, err := client.Do(req)
 		if err != nil {
+			logger.Err(err).Msg("failed to fetch prices from Coinmarketcap")
 			return nil, err
 		}
 		defer res.Body.Close()
 
 		response, err := io.ReadAll(res.Body)
 		if err != nil {
+			logger.Err(err).Msg("failed to read response body from Coinmarketcap")
 			return nil, err
 		}
 
 		rawPrices, err := getPricesFromResponse(symbols, response, logger)
 		if err != nil {
+			logger.Err(err).Msg("failed to extract prices from Coinmarketcap response")
 			return nil, err
 		}
 

--- a/feeder/priceprovider/sources/gateio.go
+++ b/feeder/priceprovider/sources/gateio.go
@@ -24,18 +24,21 @@ func GateIoPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (ra
 	url := "https://api.gateio.ws/api/v4/spot/tickers"
 	resp, err := http.Get(url)
 	if err != nil {
+		logger.Err(err).Msg("failed to fetch prices from GateIo")
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
+		logger.Err(err).Msg("failed to read response body from GateIo")
 		return nil, err
 	}
 
 	var tickers []map[string]interface{}
 	err = json.Unmarshal(b, &tickers)
 	if err != nil {
+		logger.Err(err).Msg("failed to unmarshal response body from GateIo")
 		return nil, err
 	}
 

--- a/feeder/priceprovider/sources/gateio.go
+++ b/feeder/priceprovider/sources/gateio.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/NibiruChain/nibiru/x/common/set"
+	"github.com/NibiruChain/pricefeeder/metrics"
 	"github.com/NibiruChain/pricefeeder/types"
 	"github.com/rs/zerolog"
 )
@@ -25,6 +26,7 @@ func GateIoPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (ra
 	resp, err := http.Get(url)
 	if err != nil {
 		logger.Err(err).Msg("failed to fetch prices from GateIo")
+		metrics.PriceSourceCounter.WithLabelValues(GateIo, "false").Inc()
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -32,6 +34,7 @@ func GateIoPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (ra
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Err(err).Msg("failed to read response body from GateIo")
+		metrics.PriceSourceCounter.WithLabelValues(GateIo, "false").Inc()
 		return nil, err
 	}
 
@@ -39,6 +42,7 @@ func GateIoPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (ra
 	err = json.Unmarshal(b, &tickers)
 	if err != nil {
 		logger.Err(err).Msg("failed to unmarshal response body from GateIo")
+		metrics.PriceSourceCounter.WithLabelValues(GateIo, "false").Inc()
 		return nil, err
 	}
 
@@ -59,5 +63,6 @@ func GateIoPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (ra
 		logger.Debug().Msg(fmt.Sprintf("fetched price for %s on data source %s: %f", symbol, GateIo, price))
 	}
 
+	metrics.PriceSourceCounter.WithLabelValues(GateIo, "true").Inc()
 	return rawPrices, nil
 }

--- a/feeder/priceprovider/sources/okex.go
+++ b/feeder/priceprovider/sources/okex.go
@@ -34,18 +34,21 @@ func OkexPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (rawP
 
 	resp, err := http.Get(url)
 	if err != nil {
+		logger.Err(err).Msg("failed to fetch prices from Okex")
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
+		logger.Err(err).Msg("failed to read response body from Okex")
 		return nil, err
 	}
 
 	var response OkexResponse
 	err = json.Unmarshal(b, &response)
 	if err != nil {
+		logger.Err(err).Msg("failed to unmarshal response body from Okex")
 		return nil, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/jarcoal/httpmock v1.2.0
 	github.com/joho/godotenv v1.4.0
 	github.com/rs/zerolog v1.30.0
+	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 	google.golang.org/grpc v1.58.3
 )
@@ -150,7 +151,6 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
-	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.16.0 // indirect

--- a/main.go
+++ b/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/NibiruChain/pricefeeder/cmd"
+)
+
+func main() {
+	cmd.Execute()
+}

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,30 @@
+# Pricefeeder Metrics
+
+## Available metrics
+
+### `fetched_prices_total`
+
+The total number of prices fetched from the data sources. This metric is incremented every time the price feeder fetches prices from the data sources.
+
+**labels**:
+
+- `source`: The data source from which the price was fetched, e.g. `Bybit`.
+- `success`: The result of the fetch operation. Possible values are 'true' and 'false'.
+
+### `aggregate_prices_total`
+
+The total number of times the `AggregatePriceProvider` is called to return a price. It randomly selects a source for each pair from its map of price providers. This metric is incremented every time the `AggregatePriceProvider` is called.
+
+**labels**:
+
+- `pair`: The pair for which the price was aggregated.
+- `source`: The data source from which the price was fetched, e.g. `Bybit`.
+- `success`: The result of the fetch operation. Possible values are 'true' and 'false'.
+
+### `prices_posted_total`
+
+The total number of txs sent to the on-chain oracle module. This metric is incremented every time the price feeder posts a price to the on-chain oracle module.
+
+**labels**:
+
+- `success`: The result of the post operation. Possible values are 'true' and 'false'.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -5,7 +5,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+const PrometheusNamespace = "pricefeeder"
+
 var PriceSourceCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-	Name: "price_source_counter",
-	Help: "The total number prices scraped, by source and success status",
+	Namespace: PrometheusNamespace,
+	Name:      "fetched_prices_total",
+	Help:      "The total number prices fetched, by source and success status",
 }, []string{"source", "success"})

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,11 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var PriceSourceCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "price_source_counter",
+	Help: "The total number prices scraped, by source and success status",
+}, []string{"source", "success"})


### PR DESCRIPTION
- add three custom prometheus metrics for tracking price fetching and price posting
- add more detailed logging for when individual price sources fail
- add README for new metrics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line tool for a pricefeeder daemon that posts prices to Nibiru Chain.
  - Added Prometheus metrics for tracking price fetching, aggregation, and posting operations.
  - Added a `version` command to display the current version of the software.
  - Introduced comprehensive logging for error scenarios across various price sources.

- **Documentation**
  - Updated README to reflect the latest version for running `pricefeeder`.
  - Added documentation for metrics in the new `metrics/README.md`.

- **Chores**
  - Updated build configurations and paths in `.goreleaser.yml`, Dockerfile, and Makefile for improved build processes.
  - Added a new `release-snapshot` target in the Makefile for creating release snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->