### PR TITLE
refactor: dynamic version and refactor builds

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,19 +5,23 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          go-version: 1.19
-
-      - run: make release
+          version: '~> v2'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ mockdata/
 docs
 .env
 dist
+pricefeeder

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,70 +1,49 @@
+version: 2
 project_name: pricefeeder
 
 env:
-  - CGO_ENABLED=1
+  - CGO_ENABLED=0
 
 builds:
   - id: darwin
     main: .
     binary: pricefeeder
-    hooks:
-      pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.3.0/libwasmvmstatic_darwin.a -O /osxcross/target/SDK/MacOSX12.0.sdk/usr/lib/libwasmvmstatic_darwin.a
     goos:
       - darwin
     goarch:
       - amd64
       - arm64
     env:
-      - CC=o64-clang
+      - CC_darwin_amd64=o64-clang
+      - CC_darwin_arm64=oa64-clang
+      - 'CC={{ index .Env (print "CC_" .Os "_" .Arch) }}'
     flags:
       - -mod=readonly
       - -trimpath
     ldflags:
-      - -s -w -X main.commit={{.Commit}} -X main.date={{ .CommitDate }} -X github.com/cosmos/cosmos-sdk/version.Name=nibiru -X github.com/cosmos/cosmos-sdk/version.AppName=nibid -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }} -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
-      - -linkmode=external
-    tags:
-      - netgo
-      - osusergo
-      - static_build
-      - static_wasm
-    overrides:
-      - goos: darwin
-        goarch: arm64
-        env:
-          - CC=oa64-clang
+      - -s -w
+      - -X github.com/NibiruChain/pricefeeder/cmd.Version={{ .Version }}
+      - -X github.com/NibiruChain/pricefeeder/cmd.CommitHash={{ .Commit }}
 
   - id: linux
     main: .
     binary: pricefeeder
-    hooks:
-      pre:
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.3.0/libwasmvm_muslc.x86_64.a -O /usr/lib/x86_64-linux-gnu/libwasmvm_muslc.a
-        - wget https://github.com/CosmWasm/wasmvm/releases/download/v1.3.0/libwasmvm_muslc.aarch64.a -O /usr/lib/aarch64-linux-gnu/libwasmvm_muslc.a
     goos:
       - linux
     goarch:
       - amd64
       - arm64
     env:
-      - CC=x86_64-linux-gnu-gcc
+      - CC_linux_amd64=x86_64-linux-gnu-gcc
+      - CC_linux_arm64=aarch64-linux-gnu-gcc
+      - 'CC={{ index .Env (print "CC_" .Os "_" .Arch) }}'
     flags:
       - -mod=readonly
       - -trimpath
     ldflags:
-      - -s -w -X main.commit={{.Commit}} -X main.date={{ .CommitDate }} -X github.com/cosmos/cosmos-sdk/version.Name=nibiru -X github.com/cosmos/cosmos-sdk/version.AppName=nibid -X github.com/cosmos/cosmos-sdk/version.Version={{ .Version }} -X github.com/cosmos/cosmos-sdk/version.Commit={{ .Commit }}
-      - -linkmode=external
-      - -extldflags '-Wl,-z,muldefs -static -lm'
-    tags:
-      - netgo
-      - osusergo
-      - static_build
-      - muslc
-    overrides:
-      - goos: linux
-        goarch: arm64
-        env:
-          - CC=aarch64-linux-gnu-gcc
+      - -s -w
+      - -X github.com/NibiruChain/pricefeeder/cmd.Version={{ .Version }}
+      - -X github.com/NibiruChain/pricefeeder/cmd.CommitHash={{ .Commit }}
 
 universal_binaries:
   - id: darwin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:alpine AS builder
 
+RUN apk add --no-cache build-base git
+
 WORKDIR /feeder
 
 COPY go.sum go.mod ./
@@ -7,11 +9,11 @@ RUN go mod download
 COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
   --mount=type=cache,target=/go/pkg \
-  go build -o ./build/feeder .
+  make build
 
 FROM gcr.io/distroless/static:nonroot
 
 WORKDIR /
-COPY --from=builder /feeder/build/feeder .
+COPY --from=builder /feeder/pricefeeder .
 USER nonroot:nonroot
-ENTRYPOINT ["/feeder"]
+ENTRYPOINT ["/pricefeeder"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine AS builder
 
-RUN apk add --no-cache build-base git
+RUN apk add --no-cache git make
 
 WORKDIR /feeder
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+PACKAGE_NAME		  := github.com/NibiruChain/pricefeeder
+GOLANG_CROSS_VERSION  ?= v1.19.4
+VERSION ?= $(shell git describe --tags --abbrev=0)
+COMMIT ?= $(shell git rev-parse HEAD)
+BUILD_TARGETS := build install
+
 generate:
 	go generate ./...
 
@@ -20,39 +26,6 @@ run-debug:
 ###                                Build                                    ###
 ###############################################################################
 
-.PHONY: build
-build:
-	go build -mod=readonly ./...
-
-.PHONY: install
-install:
-	go install -mod=readonly ./...
-
-###############################################################################
-###                               Release                                   ###
-###############################################################################
-
-PACKAGE_NAME		  := github.com/NibiruChain/pricefeeder
-GOLANG_CROSS_VERSION  ?= v1.19.4
-
-release:
-	docker run \
-		--rm \
-		--platform=linux/amd64 \
-		-v "$(CURDIR)":/go/src/$(PACKAGE_NAME) \
-		-w /go/src/$(PACKAGE_NAME) \
-		-e CGO_ENABLED=1 \
-		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
-		goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		release --rm-dist
-
-release-snapshot:
-	docker run \
-		--rm \
-		--platform=linux/amd64 \
-		-v "$(CURDIR)":/go/src/$(PACKAGE_NAME) \
-		-w /go/src/$(PACKAGE_NAME) \
-		-e CGO_ENABLED=1 \
-		-e GITHUB_TOKEN=${GITHUB_TOKEN} \
-		goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		release --rm-dist --snapshot
+.PHONY: build install
+$(BUILD_TARGETS):
+	CGO_ENABLED=0 go $@ -mod=readonly -ldflags="-s -w -X github.com/NibiruChain/pricefeeder/cmd.Version=$(VERSION) -X github.com/NibiruChain/pricefeeder/cmd.CommitHash=$(COMMIT)" .

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,11 +10,16 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 }
 
+var (
+	Version    string
+	CommitHash string
+)
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the version number of Hugo",
-	Long:  `All software has versions. This is Hugo's`,
+	Short: "version",
+	Long:  "Print pricefeeder version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("v1.0.3")
+		fmt.Printf("Version: %s\nCommit hash: %s\n", Version, CommitHash)
 	},
 }

--- a/config/config.go
+++ b/config/config.go
@@ -7,10 +7,16 @@ import (
 	"os"
 
 	"github.com/NibiruChain/nibiru/x/common/asset"
-	"github.com/NibiruChain/pricefeeder/feeder/priceprovider/sources"
-	"github.com/NibiruChain/pricefeeder/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/joho/godotenv"
+
+	"github.com/NibiruChain/pricefeeder/feeder/priceprovider/sources"
+	"github.com/NibiruChain/pricefeeder/types"
+)
+
+const (
+	defaultGrpcEndpoint      = "localhost:9090"
+	defaultWebsocketEndpoint = "ws://localhost:26657/websocket"
 )
 
 var defaultExchangeSymbolsMap = map[string]map[asset.Pair]types.Symbol{
@@ -85,6 +91,13 @@ func Get() (*Config, error) {
 	conf.FeederMnemonic = os.Getenv("FEEDER_MNEMONIC")
 	conf.EnableTLS = os.Getenv("ENABLE_TLS") == "true"
 	conf.ExchangesToPairToSymbolMap = defaultExchangeSymbolsMap
+
+	if conf.GRPCEndpoint == "" {
+		conf.GRPCEndpoint = defaultGrpcEndpoint
+	}
+	if conf.WebsocketEndpoint == "" {
+		conf.WebsocketEndpoint = defaultWebsocketEndpoint
+	}
 
 	overrideExchangeSymbolsMapJson := os.Getenv("EXCHANGE_SYMBOLS_MAP")
 	if overrideExchangeSymbolsMapJson != "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -9,8 +8,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestConfig_Get(t *testing.T) {
+func init() {
+	app.SetPrefixes(app.AccountAddressPrefix)
+}
 
+func TestConfig_Get(t *testing.T) {
 	os.Setenv("CHAIN_ID", "nibiru-localnet-0")
 	os.Setenv("GRPC_ENDPOINT", "localhost:9090")
 	os.Setenv("WEBSOCKET_ENDPOINT", "ws://localhost:26657/websocket")
@@ -19,21 +21,18 @@ func TestConfig_Get(t *testing.T) {
 		"EXCHANGE_SYMBOLS_MAP",
 		"{\"bitfinex\": {\"ubtc:unusd\": \"tBTCUSD\", \"ueth:unusd\": \"tETHUSD\", \"uusd:unusd\": \"tUSTUSD\"}}",
 	)
-	app.SetPrefixes(app.AccountAddressPrefix)
 	os.Setenv("VALIDATOR_ADDRESS", "nibivaloper1d7zygazerfwx4l362tnpcp0ramzm97xvv9ryxr")
 	_, err := Get()
 	require.NoError(t, err)
 }
 
 func TestConfig_Without_EXCHANGE_SYMBOLS_MAP(t *testing.T) {
-   os.Unsetenv("EXCHANGE_SYMBOLS_MAP")
+	os.Unsetenv("EXCHANGE_SYMBOLS_MAP")
 	os.Setenv("CHAIN_ID", "nibiru-localnet-0")
 	os.Setenv("GRPC_ENDPOINT", "localhost:9090")
 	os.Setenv("WEBSOCKET_ENDPOINT", "ws://localhost:26657/websocket")
 	os.Setenv("FEEDER_MNEMONIC", "earth wash broom grow recall fitness")
-	app.SetPrefixes(app.AccountAddressPrefix)
 	os.Setenv("VALIDATOR_ADDRESS", "nibivaloper1d7zygazerfwx4l362tnpcp0ramzm97xvv9ryxr")
-	cfg, err := Get()
-	fmt.Println(cfg)
+	_, err := Get()
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This PR makes a few changes:
- [x] Removes references to Hugo in `version` command.
- [x] Adds version and commit hash variables for printing in `version` command, and dynamically sets them at build time.
- [x] Simplifies builds by using pure Go and remove CGO bindings which are not necessary.
- [x] Uses normal GoReleaser instead of cross one because CGO isn't required anymore.
- [x] Reduces binary size.
- [x] Fixes config tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced workflow capabilities with updated GitHub Actions configuration for GoReleaser.
	- Dynamic version reporting in the version command, displaying application version and commit hash.
	- Introduced default constants for gRPC and WebSocket endpoints, improving configuration management.
	- Streamlined build process and improved binary naming in the Dockerfile.
	- Improved test setup organization for a consistent environment in test execution.

- **Chores**
	- Updated entries in the `.gitignore` file to maintain a clean repository.

- **Refactor**
	- Restructured Makefile for a more efficient build and installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->