### PR TITLE
feat(metrics): Add custom prometheus port support and log entry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ FEEDER_MNEMONIC="guard cream sadness conduct invite crumble clock pudding hole g
 EXCHANGE_SYMBOLS_MAP='{"bitfinex": {"ubtc:unusd": "tBTCUSD", "ueth:unusd": "tETHUSD", "uusd:unusd": "tUSTUSD"}}'
 DATASOURCE_CONFIG_MAP='{"coingecko": {"api_key": "0123456789"}}'
 VALIDATOR_ADDRESS="nibi1zaavvzxez0elundtn32qnk9lkm8kmcsz44g7xl"
+METRICS_PORT="8080"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,8 +74,10 @@ var rootCmd = &cobra.Command{
 		}
 		logger.Info().Msgf("Starting metrics server on port %s", metricsPort)
 		http.Handle("/metrics", promhttp.Handler())
-		http.ListenAndServe(":"+metricsPort, nil)
-
+		if err := http.ListenAndServe(":"+metricsPort, nil); err != nil {
+			logger.Error().Err(err).Msgf("Failed to start metrics server on port %s", metricsPort)
+			os.Exit(1)
+		}
 		select {}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,8 +68,13 @@ var rootCmd = &cobra.Command{
 
 		handleInterrupt(logger, f)
 
+		metricsPort := os.Getenv("METRICS_PORT")
+		if metricsPort == "" {
+			metricsPort = "8080"
+		}
+		logger.Info().Msgf("Starting metrics server on port %s", metricsPort)
 		http.Handle("/metrics", promhttp.Handler())
-		http.ListenAndServe(":8080", nil)
+		http.ListenAndServe(":"+metricsPort, nil)
 
 		select {}
 	},


### PR DESCRIPTION
This allows an environment variable to specify a port for prometheus in case 8080 cannot be used. It's been tested without the variable and defaults to 8080, and tested with a custom port. The log will accurately post which port prometheus is using after the binary starts.