### PR TITLE
feat: eris protocol (stnibi) custom configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,25 @@
 CHAIN_ID="nibiru-localnet-0"
+
+# Optional, defaults to localhost:9090
 GRPC_ENDPOINT="localhost:9090"
+
+# Optional, defaults to GRPC_ENDPOINT, used for reading data from the chain.
+# Example usage: read stNIBI price from the mainnet Eris protocol and submit it to testnet.
+GRPC_READ_ENDPOINT="grpc.nibiru.fi:443"
+
+# Optional, defaults to mainnet address, nibi1udqqx30cw8nwjxtl4l28ym9hhrp933zlq8dqxfjzcdhvl8y24zcqpzmh8m
+ERIS_PROTOCOL_CONTRACT_ADDRESS="nibi1udqqx30cw8nwjxtl4l28ym9hhrp933zlq8dqxfjzcdhvl8y24zcqpzmh8m"
+
+# Optional, defaults to ws://localhost:26657/websocket
 WEBSOCKET_ENDPOINT="ws://localhost:26657/websocket"
 FEEDER_MNEMONIC="guard cream sadness conduct invite crumble clock pudding hole grit liar hotel maid produce squeeze return argue turtle know drive eight casino maze host"
 EXCHANGE_SYMBOLS_MAP='{"bitfinex": {"ubtc:unusd": "tBTCUSD", "ueth:unusd": "tETHUSD", "uusd:unusd": "tUSTUSD"}}'
 DATASOURCE_CONFIG_MAP='{"coingecko": {"api_key": "0123456789"}}'
 VALIDATOR_ADDRESS="nibi1zaavvzxez0elundtn32qnk9lkm8kmcsz44g7xl"
 METRICS_PORT="8080"
+
+# Optional, used for Uniswap V3 prices, defaults to pulic ethereum RPC endpoints
 ETHEREUM_RPC_ENDPOINT="https://mainnet.infura.io/v3/<INFURA_API_KEY>"
+
+# Optional, used if custom exclusive ETHEREUM_RPC_ENDPOINT not set, defaults to public endpoints (see in the code)
 ETHEREUM_RPC_PUBLIC_ENDPOINTS="https://eth.llamarpc.com,https://cloudflare-eth.com/,https://rpc.flashbots.net/"

--- a/README.md
+++ b/README.md
@@ -133,6 +133,55 @@ ETHEREUM_RPC_ENDPOINT="https://mainnet.infura.io/v3/<INFURA_API_KEY>"
 ETHEREUM_RPC_PUBLIC_ENDPOINTS="https://eth.llamarpc.com,https://cloudflare-eth.com/,https://rpc.flashbots.net/"
 ```
 
+## Eris Protocol for stNIBI price
+
+The price of stNIBI is fetched from the Eris Protocol (CosmWasm) by GRPC.
+
+```bash
+ERIS=nibi1udqqx30cw8nwjxtl4l28ym9hhrp933zlq8dqxfjzcdhvl8y24zcqpzmh8m
+nibid q wasm contract-state smart $ERIS '{"state": {}}' | jq
+{
+  "data": {
+    "total_ustake": "51448235827733",
+    "total_utoken": "67090804824813",
+    "exchange_rate": "1.304044808250702453",
+    "unlocked_coins": [
+      {
+        "denom": "unibi",
+        "amount": "509884"
+      }
+    ],
+    "unbonding": "749733010863",
+    "available": "552036314217",
+    "tvl_utoken": "68392574149893"
+  }
+}
+```
+
+By default, the pricefeeder will use the local GRPC endpoint, the same as pricefeeder is using to submit the prices.
+To allow fetching the mainnet price and submit it to testnet/localnet, you can set the following environment variable:
+
+```ini
+# Mainnet
+GRPC_READ_ENDPOINT="grpc.nibiru.fi:443"
+
+# Testnet-2
+GRPC_READ_ENDPOINT="grpc-testnet-2.nibiru.fi:443"
+```
+
+Eris protocol contract address is defaulted to mainnet address.
+To customize it, you can set the following environment variable:
+
+```ini
+# Mainnet
+ERIS_PROTOCOL_CONTRACT_ADDRESS="nibi1udqqx30cw8nwjxtl4l28ym9hhrp933zlq8dqxfjzcdhvl8y24zcqpzmh8m"
+
+# Testnet-2
+ERIS_PROTOCOL_CONTRACT_ADDRESS="nibi1keqw4dllsczlldd7pmzp25wyl04fw5anh3wxljhg4fjuqj9xnxuqa82rpg"
+```
+
+```ini
+
 ## Glossary
 
 - **Data source**: A data source is an external service that provides data. For example, Binance is a data source that provides the price of various assets.

--- a/README.md
+++ b/README.md
@@ -180,8 +180,6 @@ ERIS_PROTOCOL_CONTRACT_ADDRESS="nibi1udqqx30cw8nwjxtl4l28ym9hhrp933zlq8dqxfjzcdh
 ERIS_PROTOCOL_CONTRACT_ADDRESS="nibi1keqw4dllsczlldd7pmzp25wyl04fw5anh3wxljhg4fjuqj9xnxuqa82rpg"
 ```
 
-```ini
-
 ## Glossary
 
 - **Data source**: A data source is an external service that provides data. For example, Binance is a data source that provides the price of various assets.

--- a/feeder/priceprovider/aggregatepriceprovider_test.go
+++ b/feeder/priceprovider/aggregatepriceprovider_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestAggregatePriceProvider(t *testing.T) {
 	t.Run("eris protocol success", func(t *testing.T) {
+		t.Setenv("GRPC_READ_ENDPOINT", "grpc.nibiru.fi:443")
 		pp := NewAggregatePriceProvider(
 			map[string]map[asset.Pair]types.Symbol{
 				sources.ErisProtocol: {
@@ -29,7 +30,7 @@ func TestAggregatePriceProvider(t *testing.T) {
 			zerolog.New(io.Discard),
 		)
 		defer pp.Close()
-		<-time.After(sources.UpdateTick + 2*time.Second)
+		<-time.After(sources.UpdateTick + 5*time.Second)
 
 		price := pp.GetPrice("ustnibi:uusd")
 		require.True(t, price.Valid)

--- a/feeder/priceprovider/priceprovider_test.go
+++ b/feeder/priceprovider/priceprovider_test.go
@@ -44,6 +44,7 @@ func TestPriceProvider(t *testing.T) {
 	})
 
 	t.Run("eris protocol success", func(t *testing.T) {
+		t.Setenv("GRPC_READ_ENDPOINT", "grpc.nibiru.fi:443")
 		pp := NewPriceProvider(
 			sources.ErisProtocol,
 			map[asset.Pair]types.Symbol{asset.NewPair("ustnibi", denoms.NIBI): "ustnibi:unibi"},

--- a/feeder/priceprovider/sources/eris_protocol.go
+++ b/feeder/priceprovider/sources/eris_protocol.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"google.golang.org/grpc/credentials/insecure"
+	"os"
 	"strconv"
+	"strings"
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/NibiruChain/nibiru/x/common/set"
@@ -20,23 +23,33 @@ import (
 const (
 	ErisProtocol = "eris_protocol"
 	// Configuration constants
-	grpcEndpoint = "grpc.nibiru.fi:443"
-	contractAddr = "nibi1udqqx30cw8nwjxtl4l28ym9hhrp933zlq8dqxfjzcdhvl8y24zcqpzmh8m"
-	stateQuery   = `{"state": {}}`
+	stateQuery = `{"state": {}}`
 )
+
+var grpcReadEndpoint string
 
 var _ types.FetchPricesFunc = ErisProtocolPriceUpdate
 
 // newGRPCConnection creates a new gRPC connection with TLS
 func newGRPCConnection() (*grpc.ClientConn, error) {
-	transportDialOpt := grpc.WithTransportCredentials(
-		credentials.NewTLS(
+	grpcReadEndpoint = os.Getenv("GRPC_READ_ENDPOINT")
+	if grpcReadEndpoint == "" {
+		grpcReadEndpoint = os.Getenv("GRPC_ENDPOINT")
+	}
+	if grpcReadEndpoint == "" {
+		grpcReadEndpoint = "localhost:9090"
+	}
+	enableTLS := os.Getenv("ENABLE_TLS") == "true" || strings.Contains(grpcReadEndpoint, ":443")
+	creds := insecure.NewCredentials()
+	if enableTLS {
+		creds = credentials.NewTLS(
 			&tls.Config{
 				InsecureSkipVerify: false,
 			},
-		),
-	)
-	return grpc.Dial(grpcEndpoint, transportDialOpt)
+		)
+	}
+	transportDialOpt := grpc.WithTransportCredentials(creds)
+	return grpc.Dial(grpcReadEndpoint, transportDialOpt)
 }
 
 // ErisProtocolPriceUpdate retrieves the exchange rate for stNIBI to NIBI (ustnibi:unibi) from the Eris Protocol smart contract.
@@ -44,15 +57,20 @@ func newGRPCConnection() (*grpc.ClientConn, error) {
 func ErisProtocolPriceUpdate(symbols set.Set[types.Symbol], logger zerolog.Logger) (rawPrices map[types.Symbol]float64, err error) {
 	conn, err := newGRPCConnection()
 	if err != nil {
-		logger.Err(err).Msgf("failed to connect to gRPC endpoint %s", grpcEndpoint)
+		logger.Err(err).Msgf("failed to connect to gRPC endpoint %s", grpcReadEndpoint)
 		metrics.PriceSourceCounter.WithLabelValues(ErisProtocol, "false").Inc()
-		return nil, fmt.Errorf("failed to connect to gRPC endpoint %s: %w", grpcEndpoint, err)
+		return nil, fmt.Errorf("failed to connect to gRPC endpoint %s: %w", grpcReadEndpoint, err)
 	}
 	defer func() {
 		if closeErr := conn.Close(); closeErr != nil {
 			logger.Err(closeErr).Msg("failed to close gRPC connection")
 		}
 	}()
+
+	contractAddr := os.Getenv("ERIS_PROTOCOL_CONTRACT_ADDRESS")
+	if contractAddr == "" {
+		contractAddr = "nibi1udqqx30cw8nwjxtl4l28ym9hhrp933zlq8dqxfjzcdhvl8y24zcqpzmh8m" // mainnet
+	}
 
 	wasmClient := wasmtypes.NewQueryClient(conn)
 	query := wasmtypes.QuerySmartContractStateRequest{

--- a/feeder/priceprovider/sources/eris_protocol_test.go
+++ b/feeder/priceprovider/sources/eris_protocol_test.go
@@ -12,6 +12,7 @@ import (
 
 func TestErisProtocolPriceUpdate(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
+		t.Setenv("GRPC_READ_ENDPOINT", "grpc.nibiru.fi:443")
 		rawPrices, err := ErisProtocolPriceUpdate(set.New[types.Symbol](), zerolog.New(io.Discard))
 		require.NoError(t, err)
 		require.Equal(t, 1, len(rawPrices))


### PR DESCRIPTION
## Features:
- selecting endpoint for GRPC reading instead of the hardcoded `grpc.nibiru.fi:443`
- selecting contract address for stNIBI instead of hardcoded mainnet version `nibi1udqqx30cw8nwjxtl4l28ym9hhrp933zlq8dqxfjzcdhvl8y24zcqpzmh8m`