### PR TITLE
feat: integrate Chainlink and Pyth price feeds for ynETHx:ETH 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- feat: add Chainlink and Pyth ynETHx:ETH feeds plus aggregate ynETH:USD pricing
 - [#67](https://github.com/NibiruChain/pricefeeder/pull/67) - feat: update deps and code for Nibiru v2 (v2.6.0)
 - [#63](https://github.com/NibiruChain/pricefeeder/pull/63) - chore: add changelog
 - [#64](https://github.com/NibiruChain/pricefeeder/pull/64) - feat: Uniswap V3 data source for USDa from Avalon.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ Types of changes (Stanzas):
 Ref: https://keepachangelog.com/en/1.0.0/
 -->
 
-
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -39,7 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- feat: add Chainlink and Pyth ynETHx:ETH feeds plus aggregate ynETH:USD pricing
+- [#92](https://github.com/NibiruChain/pricefeeder/pull/92) - feat: add Chainlink and Pyth ynETHx:ETH feeds plus aggregate ynETH:USD pricing
 - [#67](https://github.com/NibiruChain/pricefeeder/pull/67) - feat: update deps and code for Nibiru v2 (v2.6.0)
 - [#63](https://github.com/NibiruChain/pricefeeder/pull/63) - chore: add changelog
 - [#64](https://github.com/NibiruChain/pricefeeder/pull/64) - feat: Uniswap V3 data source for USDa from Avalon.
@@ -53,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#46](https://github.com/NibiruChain/pricefeeder/pull/46) - refactor: dynamic version and refactor builds
 - [#47](https://github.com/NibiruChain/pricefeeder/pull/47) - Suggestion to allow better precision for exchange rates
-- [#55](https://github.com/NibiruChain/pricefeeder/pull/55) - fix(priceprovider-bybit): add special exception for blocked regions in bybit test 
+- [#55](https://github.com/NibiruChain/pricefeeder/pull/55) - fix(priceprovider-bybit): add special exception for blocked regions in bybit test
 - f2de02b chore(github): Add project automation for https://tinyurl.com/25uty9w5
 - [#59](https://github.com/NibiruChain/pricefeeder/pull/59) - fix: reset httpmock before register responder
 - [#60](https://github.com/NibiruChain/pricefeeder/pull/60) - chore: lint workflow
@@ -65,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v1.0.3
 
-- [#45](https://github.com/NibiruChain/pricefeeder/pull/45) - feat(observability): add prometheus metrics and detailed logging 
+- [#45](https://github.com/NibiruChain/pricefeeder/pull/45) - feat(observability): add prometheus metrics and detailed logging
 - [#40](https://github.com/NibiruChain/pricefeeder/pull/40) - avoid parsing if EXCHANGE_SYMBOLS_MAP is not define.
 
 ## v1.0.2

--- a/README.md
+++ b/README.md
@@ -204,6 +204,41 @@ B2_RPC_ENDPOINT="https://mainnet.b2-rpc.com"
 
 # Optional, used if custom exclusive B2_RPC_ENDPOINT not set, defaults to public endpoints (see in the code)
 B2_RPC_PUBLIC_ENDPOINTS="https://rpc.bsquared.network,https://mainnet.b2-rpc.com"
+
+# Optional, override the Base mainnet RPC used for Chainlink feeds deployed on Base
+BASE_RPC_ENDPOINT="https://mainnet.base.org"
+
+# Optional, comma separated list of fallback Base RPC endpoints
+BASE_RPC_PUBLIC_ENDPOINTS="https://mainnet.base.org,https://base-rpc.publicnode.com"
+```
+
+### Pyth Network API
+
+The Pyth data source consumes prices from the public Hermes REST API. By default
+the feeder queries `https://hermes.pyth.network/v2/updates/price/latest` and
+aggregates the parsed price objects for the configured feed IDs.
+
+You can override the endpoint, request timeout, or accepted staleness via the
+`DATASOURCE_CONFIG_MAP` env var, for example:
+
+```ini
+DATASOURCE_CONFIG_MAP='{
+  "pyth": {
+    "endpoint": "https://hermes.pyth.network",
+    "timeout_seconds": 10,
+    "max_price_age_seconds": 120
+  }
+}'
+```
+
+Two feeds are enabled by default:
+
+- `ynethx:eth` – mapped to feed ID `0x741f2ecf4436868e4642db088fa33f9858954b992285129c9b03917dcb067ecc`
+- `eth:usd` – mapped to feed ID `0xff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace`
+
+These prices are also reused to build the aggregate `yneth:usd` pair inside the
+`AggregatePriceProvider` by multiplying `ynethx:eth` with the best available
+`eth:usd` (or legacy `ueth:uusd`) quote.
 ```
 
 ## Glossary

--- a/config/config.go
+++ b/config/config.go
@@ -80,11 +80,17 @@ var defaultExchangeSymbolsMap = map[string]map[asset.Pair]types.Symbol{
 	},
 
 	sources.SourceNameChainLink: {
-		"b2btc:btc": "uBTC/BTC",
+		"b2btc:btc":  "uBTC/BTC",
+		"ynethx:eth": "ynETHx/ETH",
 	},
 
 	sources.SourceNameAvalon: {
 		"susda:usda": "susda:usda",
+	},
+
+	sources.SourceNamePyth: {
+		"ynethx:eth": "741f2ecf4436868e4642db088fa33f9858954b992285129c9b03917dcb067ecc",
+		"eth:usd":    "ff61491a931112ddf1bd8147cd1b641375f79f5825126d665480874634fd0ace",
 	},
 }
 

--- a/sources/chainlink.go
+++ b/sources/chainlink.go
@@ -26,7 +26,8 @@ const (
 type ChainType string
 
 const (
-	ChainB2 ChainType = "b2"
+	ChainB2   ChainType = "b2"
+	ChainBase ChainType = "base"
 )
 
 // ChainlinkConfig represents configuration for a specific Chainlink oracle
@@ -45,11 +46,18 @@ var chainlinkConfigMap = map[types.Symbol]ChainlinkConfig{
 		Description:     "uBTC/BTC Exchange Rate",
 		MaxDataAge:      0, // No age limit for this example
 	},
+	"ynETHx/ETH": {
+		Chain:           ChainBase,
+		ContractAddress: common.HexToAddress("0xb4482096e3cdE116C15fC0D700a73a58FEdeB8c0"),
+		Description:     "ynETH / ETH Exchange Rate",
+		MaxDataAge:      0,
+	},
 }
 
 // chainConnectors maps chain types to their connection functions
 var chainConnectors = map[ChainType]func(time.Duration, zerolog.Logger) (*ethclient.Client, error){
-	ChainB2: types.ConnectToB2,
+	ChainB2:   types.ConnectToB2,
+	ChainBase: types.ConnectToBase,
 }
 
 // ChainlinkPriceUpdate retrieves exchange rates from various Chainlink oracles across different chains

--- a/sources/chainlink_test.go
+++ b/sources/chainlink_test.go
@@ -18,15 +18,17 @@ func TestChainlinkPriceUpdate(t *testing.T) {
 
 	symbols := set.New[types.Symbol]()
 	symbols.Add("uBTC/BTC")
+	symbols.Add("ynETHx/ETH")
 	symbols.Add("foo:bar")
 
 	prices, err := ChainlinkPriceUpdate(symbols, logger)
 
 	require.NoError(t, err)
-	require.Len(t, prices, 1)
+	require.Len(t, prices, 2)
 
 	price := prices["uBTC/BTC"]
 	assert.Greater(t, price, 0.0)
+	assert.Greater(t, prices["ynETHx/ETH"], 0.0)
 
 	_, unknownExists := prices["foo/bar"]
 	assert.False(t, unknownExists)

--- a/sources/pyth.go
+++ b/sources/pyth.go
@@ -1,0 +1,186 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/NibiruChain/nibiru/v2/x/common/set"
+	"github.com/rs/zerolog"
+
+	"github.com/NibiruChain/pricefeeder/metrics"
+	"github.com/NibiruChain/pricefeeder/types"
+)
+
+const (
+	SourceNamePyth         = "pyth"
+	defaultPythEndpoint    = "https://hermes.pyth.network"
+	defaultPythTimeout     = 10 * time.Second
+	defaultPythMaxPriceAge = 2 * time.Minute
+	pythLatestPricePath    = "/v2/updates/price/latest"
+	pythQueryParamParsed   = "parsed"
+	pythQueryParamIDs      = "ids[]"
+	pythQueryValueParsed   = "true"
+)
+
+type pythConfig struct {
+	Endpoint           string `json:"endpoint"`
+	TimeoutSeconds     int    `json:"timeout_seconds"`
+	MaxPriceAgeSeconds int    `json:"max_price_age_seconds"`
+}
+
+type pythLatestPriceResponse struct {
+	Parsed []pythParsedPrice `json:"parsed"`
+}
+
+type pythParsedPrice struct {
+	ID    string           `json:"id"`
+	Price pythPricePayload `json:"price"`
+}
+
+type pythPricePayload struct {
+	Price       string `json:"price"`
+	Expo        int32  `json:"expo"`
+	PublishTime int64  `json:"publish_time"`
+}
+
+var _ types.FetchPricesFunc = PythPriceUpdate(nil)
+
+// PythPriceUpdate builds a price fetcher backed by the Hermes REST API.
+// Optional configuration is provided via the datasource config map and allows
+// overriding the endpoint, timeout, and maximum accepted data age.
+func PythPriceUpdate(rawCfg json.RawMessage) types.FetchPricesFunc {
+	return func(symbols set.Set[types.Symbol], logger zerolog.Logger) (map[types.Symbol]float64, error) {
+		cfg := defaultPythConfig()
+		if len(rawCfg) > 0 {
+			if err := json.Unmarshal(rawCfg, &cfg); err != nil {
+				metrics.PriceSourceCounter.WithLabelValues(SourceNamePyth, "false").Inc()
+				return nil, fmt.Errorf("invalid pyth config: %w", err)
+			}
+		}
+
+		return fetchPythPrices(symbols, cfg, logger)
+	}
+}
+
+func defaultPythConfig() pythConfig {
+	return pythConfig{
+		Endpoint:           defaultPythEndpoint,
+		TimeoutSeconds:     int(defaultPythTimeout / time.Second),
+		MaxPriceAgeSeconds: int(defaultPythMaxPriceAge / time.Second),
+	}
+}
+
+func fetchPythPrices(symbols set.Set[types.Symbol], cfg pythConfig, logger zerolog.Logger) (map[types.Symbol]float64, error) {
+	if symbols.Len() == 0 {
+		metrics.PriceSourceCounter.WithLabelValues(SourceNamePyth, "false").Inc()
+		return nil, fmt.Errorf("no symbols configured for pyth")
+	}
+
+	endpoint := cfg.Endpoint
+	if endpoint == "" {
+		endpoint = defaultPythEndpoint
+	}
+
+	timeout := time.Duration(cfg.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = defaultPythTimeout
+	}
+
+	maxAge := time.Duration(cfg.MaxPriceAgeSeconds) * time.Second
+	if maxAge <= 0 {
+		maxAge = defaultPythMaxPriceAge
+	}
+
+	req, err := http.NewRequest(http.MethodGet, endpoint+pythLatestPricePath, nil)
+	if err != nil {
+		metrics.PriceSourceCounter.WithLabelValues(SourceNamePyth, "false").Inc()
+		return nil, fmt.Errorf("failed to create pyth request: %w", err)
+	}
+
+	q := req.URL.Query()
+	for symbol := range symbols {
+		q.Add(pythQueryParamIDs, string(symbol))
+	}
+	q.Set(pythQueryParamParsed, pythQueryValueParsed)
+	req.URL.RawQuery = q.Encode()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		metrics.PriceSourceCounter.WithLabelValues(SourceNamePyth, "false").Inc()
+		return nil, fmt.Errorf("pyth http request failed: %w", err)
+	}
+	defer func() {
+		if errClose := resp.Body.Close(); errClose != nil {
+			logger.Err(errClose).Str("source", SourceNamePyth).Msg("failed to close pyth response body")
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		metrics.PriceSourceCounter.WithLabelValues(SourceNamePyth, "false").Inc()
+		return nil, fmt.Errorf("pyth returned non-200 status: %s", resp.Status)
+	}
+
+	var parsedResp pythLatestPriceResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsedResp); err != nil {
+		metrics.PriceSourceCounter.WithLabelValues(SourceNamePyth, "false").Inc()
+		return nil, fmt.Errorf("failed to decode pyth response: %w", err)
+	}
+
+	if len(parsedResp.Parsed) == 0 {
+		metrics.PriceSourceCounter.WithLabelValues(SourceNamePyth, "false").Inc()
+		return nil, fmt.Errorf("pyth response missing parsed prices")
+	}
+
+	prices := make(map[types.Symbol]float64, len(parsedResp.Parsed))
+	for _, priceEntry := range parsedResp.Parsed {
+		price, err := convertPythPrice(priceEntry.Price.Price, priceEntry.Price.Expo)
+		if err != nil {
+			logger.Err(err).
+				Str("id", priceEntry.ID).
+				Msg("pyth conversion error")
+			continue
+		}
+
+		publishTime := time.Unix(priceEntry.Price.PublishTime, 0)
+		if age := time.Since(publishTime); age > maxAge {
+			logger.Warn().
+				Str("id", priceEntry.ID).
+				Dur("age", age).
+				Dur("max_age", maxAge).
+				Msg("pyth price stale")
+		}
+
+		prices[types.Symbol(priceEntry.ID)] = price
+		logger.Debug().Str("source", SourceNamePyth).
+			Str("id", priceEntry.ID).
+			Float64("price", price).
+			Msg("fetched pyth price")
+	}
+
+	if len(prices) == 0 {
+		metrics.PriceSourceCounter.WithLabelValues(SourceNamePyth, "false").Inc()
+		return nil, fmt.Errorf("pyth returned zero valid prices")
+	}
+
+	metrics.PriceSourceCounter.WithLabelValues(SourceNamePyth, "true").Inc()
+	return prices, nil
+}
+
+func convertPythPrice(priceStr string, expo int32) (float64, error) {
+	intVal, ok := new(big.Int).SetString(priceStr, 10)
+	if !ok {
+		return 0, fmt.Errorf("invalid price string: %s", priceStr)
+	}
+
+	floatVal, _ := new(big.Float).SetInt(intVal).Float64()
+	return floatVal * math.Pow10(int(expo)), nil
+}

--- a/sources/pyth_test.go
+++ b/sources/pyth_test.go
@@ -51,7 +51,8 @@ func TestPythPriceUpdate_CustomEndpoint(t *testing.T) {
 
 func TestPythPriceUpdate_EmptyParsedReturnsError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"parsed":[]}`))
+		_, writeErr := w.Write([]byte(`{"parsed":[]}`))
+		require.NoError(t, writeErr)
 	}))
 	defer server.Close()
 

--- a/sources/pyth_test.go
+++ b/sources/pyth_test.go
@@ -1,0 +1,80 @@
+package sources
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/NibiruChain/nibiru/v2/x/common/set"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NibiruChain/pricefeeder/types"
+)
+
+func TestPythPriceUpdate_CustomEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v2/updates/price/latest", r.URL.Path)
+		require.ElementsMatch(t, []string{"feed-1", "feed-2"}, r.URL.Query()[pythQueryParamIDs])
+		require.Equal(t, pythQueryValueParsed, r.URL.Query().Get(pythQueryParamParsed))
+
+		publishTime := time.Now().Add(-30 * time.Second).Unix()
+		fmt.Fprintf(w, `{"parsed":[
+			{"id":"feed-1","price":{"price":"123456","expo":-2,"publish_time":%d}},
+			{"id":"feed-2","price":{"price":"987654321","expo":-4,"publish_time":%d}}
+		]}`, publishTime, publishTime)
+	}))
+	defer server.Close()
+
+	cfgBytes, err := json.Marshal(pythConfig{
+		Endpoint:           server.URL,
+		TimeoutSeconds:     1,
+		MaxPriceAgeSeconds: 60,
+	})
+	require.NoError(t, err)
+
+	fetchPrices := PythPriceUpdate(cfgBytes)
+	symbols := set.New[types.Symbol]("feed-1", "feed-2")
+	logger := zerolog.New(io.Discard)
+
+	prices, err := fetchPrices(symbols, logger)
+	require.NoError(t, err)
+	require.Len(t, prices, 2)
+	assert.InDelta(t, 1234.56, prices["feed-1"], 1e-9)
+	assert.InDelta(t, 98765.4321, prices["feed-2"], 1e-9)
+}
+
+func TestPythPriceUpdate_EmptyParsedReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"parsed":[]}`))
+	}))
+	defer server.Close()
+
+	cfgBytes, err := json.Marshal(pythConfig{Endpoint: server.URL})
+	require.NoError(t, err)
+
+	fetchPrices := PythPriceUpdate(cfgBytes)
+	logger := zerolog.New(io.Discard)
+	_, err = fetchPrices(set.New[types.Symbol]("feed-1"), logger)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing parsed prices")
+}
+
+func TestConvertPythPrice(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		price, err := convertPythPrice("123456", -2)
+		require.NoError(t, err)
+		assert.InDelta(t, 1234.56, price, 1e-9)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := convertPythPrice("not-a-number", 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid price string")
+	})
+}

--- a/sources/sources.go
+++ b/sources/sources.go
@@ -189,4 +189,14 @@ var allSources = []NamedSource{
 			return NewTickSource(symbols, ChainlinkPriceUpdate, logger)
 		},
 	},
+	{
+		Name: SourceNamePyth,
+		F: func(
+			symbols set.Set[types.Symbol],
+			cfg json.RawMessage,
+			logger zerolog.Logger,
+		) types.Source {
+			return NewTickSource(symbols, PythPriceUpdate(cfg), logger)
+		},
+	},
 }

--- a/types/ethereum_call.go
+++ b/types/ethereum_call.go
@@ -45,6 +45,16 @@ var DefaultNetworkConfigs = map[string]NetworkConfig{
 		EnvEndpoint:        "B2_RPC_ENDPOINT",
 		EnvPublicEndpoints: "B2_RPC_PUBLIC_ENDPOINTS",
 	},
+	"base": {
+		Name: "base",
+		DefaultEndpoints: []string{
+			"https://mainnet.base.org",
+			"https://base-rpc.publicnode.com",
+			"https://1rpc.io/base",
+		},
+		EnvEndpoint:        "BASE_RPC_ENDPOINT",
+		EnvPublicEndpoints: "BASE_RPC_PUBLIC_ENDPOINTS",
+	},
 }
 
 // Global variables to track the last working RPC endpoint per network
@@ -203,4 +213,8 @@ func ConnectToEthereum(timeout time.Duration, logger zerolog.Logger) (*ethclient
 
 func ConnectToB2(timeout time.Duration, logger zerolog.Logger) (*ethclient.Client, error) {
 	return ConnectToNetwork("b2", timeout, logger)
+}
+
+func ConnectToBase(timeout time.Duration, logger zerolog.Logger) (*ethclient.Client, error) {
+	return ConnectToNetwork("base", timeout, logger)
 }

--- a/types/ethereum_call_test.go
+++ b/types/ethereum_call_test.go
@@ -42,6 +42,21 @@ func TestConnectToEthereum(t *testing.T) {
 	assert.Greater(t, blockNumber, uint64(0))
 }
 
+func TestConnectToBase(t *testing.T) {
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	timeout := 10 * time.Second
+
+	client, err := ConnectToBase(timeout, logger)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	defer client.Close()
+
+	blockNumber, err := client.BlockNumber(context.Background())
+	require.NoError(t, err)
+	assert.Greater(t, blockNumber, uint64(0))
+}
+
 func TestGetRPCEndpoints(t *testing.T) {
 	endpoints, err := GetRPCEndpoints("b2")
 


### PR DESCRIPTION
This pull request introduces support for Chainlink and Pyth price feeds for the `ynETHx:ETH` pair and enables aggregation of `ynETH:USD` pricing by combining these feeds. It also adds the Pyth Network as a new data source, updates the configuration and documentation to reflect these changes, and enhances testing to ensure the new features work as expected.

**New Data Sources and Feed Integrations:**

* Added support for Chainlink and Pyth feeds for `ynETHx:ETH`, including configuration for the Base network and contract address in `chainlink.go` and symbol mapping in `config.go`. [[1]](diffhunk://#diff-1d77e51e743db5712221aec4b6ad6107b1b7d1d7ef2729ce9545e167ab2d410bR30) [[2]](diffhunk://#diff-1d77e51e743db5712221aec4b6ad6107b1b7d1d7ef2729ce9545e167ab2d410bR49-R60) [[3]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R84-R94)
* Introduced the Pyth Network as a new price source, with a full implementation (`pyth.go`), integration into the source registry (`sources.go`), and symbol mapping for `ynethx:eth` and `eth:usd`. [[1]](diffhunk://#diff-6038d605b9e59c9163b5f42cbc091de2a93807694387559acb0629a825257b5cR1-R186) [[2]](diffhunk://#diff-0227cc052c7a7b50dc0ae492a6d613dd1da9da89a7ee4eece901333666826000R192-R201) [[3]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R84-R94)

**Aggregate Price Calculation:**

* Implemented logic in `AggregatePriceProvider` to compute the `yneth:usd` price by multiplying `ynethx:eth` with the best available `eth:usd` (or fallback to `ueth:uusd`), ensuring robust aggregation.

**Configuration and Documentation Updates:**

* Updated `README.md` to document the new Pyth data source, its configuration, and the new environment variables for the Base network.
* Updated `CHANGELOG.md` to reflect the addition of Chainlink and Pyth feeds and the aggregate `ynETH:USD` pricing.

**Testing Enhancements:**

* Added comprehensive tests for the new Pyth source (`pyth_test.go`), extended aggregate price provider tests to cover the new aggregation logic and fallbacks, and updated Chainlink tests to include the new `ynETHx/ETH` feed. [[1]](diffhunk://#diff-7ad8d35cb029d7efd26f9f527eec2d9e71f5c8a667a6f657fee3fd7c04d09f47R1-R80) [[2]](diffhunk://#diff-781ae51ec4f9a6ad993c7ec44423efaddc403cccb0871aad5d68561ba7fd1d3aL213-R295) [[3]](diffhunk://#diff-f849321feff92eabc72a0b16437ad467b2a7d2547146c1e5ce5f36ba2b66680bR21-R31)
* Added a stub price provider for easier testing of aggregation logic and improved test robustness by skipping unavailable prices instead of failing. [[1]](diffhunk://#diff-781ae51ec4f9a6ad993c7ec44423efaddc403cccb0871aad5d68561ba7fd1d3aR35-R52) [[2]](diffhunk://#diff-781ae51ec4f9a6ad993c7ec44423efaddc403cccb0871aad5d68561ba7fd1d3aL213-R295)

**Ethereum Network Support:**

* Added support for the Base network in Ethereum connection utilities, including configuration, connection logic, and tests. [[1]](diffhunk://#diff-3cc5295214e0e21b0442b827ad3d20de4c53875b2055119f3e05c9df39b2b826R48-R57) [[2]](diffhunk://#diff-3cc5295214e0e21b0442b827ad3d20de4c53875b2055119f3e05c9df39b2b826R217-R220) [[3]](diffhunk://#diff-424f0a8f88cc69c0681bc7348c70993d4d44530c001a4285622aaefc72a10769R45-R59)

These changes collectively enhance the system’s ability to source and aggregate prices for new assets, improve configurability, and ensure reliability through robust testing.